### PR TITLE
Fix typo steto to stetho

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Used Libs
 * [Coroutines](https://developer.android.com/kotlin/coroutines) 
 * [Coroutines-flow](https://kotlinlang.org/docs/reference/coroutines/flow.html) 
 * [Retrofit2](https://square.github.io/retrofit/) 
-* [steto](http://facebook.github.io/stetho/) 
+* [stetho](http://facebook.github.io/stetho/)
 * [coil](https://coil-kt.github.io/coil/) 
 
 Screenshot


### PR DESCRIPTION
I was going through your repo to learn about MVI, and found this typo. Thought of fixing this as I have already forked it. Between the article you wrote on medium was really good. Thanks for that.